### PR TITLE
Replace BUILD_file_generator with Jadep

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ Skylark is Bazel's domain-specific language for writing BUILD definitions and ru
 
 - [migration-tooling](https://github.com/bazelbuild/migration-tooling/) - Migrate an existing Maven project to Bazel.
 - [bazel-deps](https://github.com/johnynek/bazel-deps) - Generate bazel dependencies transitively for Maven artifacts, with scala support.
-- [BUILD_file_generator](https://github.com/bazelbuild/BUILD_file_generator) - Generate BUILD files automatically for an existing Java project with class dependency analysis.
+- [Jadep: Java Automated Dependencies](https://github.com/bazelbuild/tools_jvm_autodeps) - Generate BUILD files automatically for an existing Java project with class dependency analysis.
 - [rules_maven](https://github.com/pubref/rules_maven) - Rules to define Maven dependencies
 
 ### Editors


### PR DESCRIPTION
It seems Jadep is the direction Carmi is going for automating BUILD file generation. I removed bfg from the list (rather than keeping both) largely because bfg is currently not functional. 