### PR TITLE
Add Bazel Community Slack to Awesome Bazel page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# Awesome Bazel [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+# Awesome Bazel
+[![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
+[![Slack](http://bazel-slackin.herokuapp.com/badge.svg)](https://bazel-slackin.herokuapp.com)
 
 <p align="center">
 	<img height="300" src="https://bazel.build/images/bazel-icon.svg"></img>
@@ -626,6 +628,7 @@ A list of projects built with Bazel:
 
 ### Community
 
+- [#bazelbuild on Slack](https://bazel-slackin.herokuapp.com)
 - [`#bazel` on Freenode](http://webchat.freenode.net/?channels=bazel)
 - [Stack Overflow](http://stackoverflow.com/questions/tagged/bazel)
 - [Bazel users mailing list](https://groups.google.com/forum/#!forum/bazel-discuss)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# Awesome Bazel
-[![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
-[![Slack](http://bazel-slackin.herokuapp.com/badge.svg)](https://bazel-slackin.herokuapp.com)
+# Awesome Bazel [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) [![Slack](http://bazel-slackin.herokuapp.com/badge.svg)](https://bazel-slackin.herokuapp.com)
 
 <p align="center">
 	<img height="300" src="https://bazel.build/images/bazel-icon.svg"></img>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Awesome Bazel [![Awesome](https://awesome.re/badge.svg)](https://awesome.re) [![Slack](http://bazel-slackin.herokuapp.com/badge.svg)](https://bazel-slackin.herokuapp.com)
+# Awesome Bazel [![Awesome](https://awesome.re/badge.svg)](https://awesome.re)
 
 <p align="center">
 	<img height="300" src="https://bazel.build/images/bazel-icon.svg"></img>


### PR DESCRIPTION
As developers, collaboration is critical in our daily workflow, especially for _"bleeding edge"_ tech where the developers are spread across the world. Open chat platforms have been instrumental to the growth of such community, and Slack has proven to help many tech stacks grow this way. We'd love to make this happen for Bazel too!