### PR TITLE
Add rules_container_rpm to container section

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,12 @@ Have something to contribute or discuss? [Open a pull request](https://github.co
             <td>Docker</td>
             <td>
                 <ul>
-                    <li><a href="https://github.com/bazelbuild/rules_docker">bazelbuild/rules_docker</a></li>
+                    <li>
+                        <a href="https://github.com/bazelbuild/rules_docker">bazelbuild/rules_docker</a>
+                    </li>
+                    <li>
+                        <div><a href="https://github.com/rmohr/rules_container_rpm">rmohr/rules_container_rpm</a>: Install RPMs without a container daemon with bazel</div>
+                    </li>
                 </ul>
             </td>
         </tr>


### PR DESCRIPTION
It would be great if https://github.com/rmohr/rules_container_rpm could be added to the list. I find it very useful to create minimal RPM-based containers with bazel and some outhers may find it useful too: https://github.com/bazelbuild/rules_docker/issues/203.