### PR TITLE
Remove cgruber's fork of Kotlin rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,9 +358,6 @@ Have something to contribute or discuss? [Open a pull request](https://github.co
         <ul>
           <li><a href="https://github.com/bazelbuild/rules_kotlin">bazelbuild/rules_kotlin</a></li>
         </ul>
-        <ul>
-          <li><a href="https://github.com/cgruber/rules_kotlin">cgruber/rules_kotlin</a> (a temporary maintenance fork of the legacy rules above, until Google releases their updated rules, including 1.3 support)</li>
-        </ul>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
This fork has been merged (and tagged) upstream.