### PR TITLE
Add Brightspace/rules_csharp

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,14 +51,6 @@ Have something to contribute or discuss? [Open a pull request](https://github.co
   </thead>
   <tbody>
     <tr>
-      <td>.NET (C#, Nuget)</td>
-      <td>
-        <ul>
-          <li><a href="https://github.com/bazelbuild/rules_dotnet">bazelbuild/rules_dotnet</a></li>
-        </ul>
-      </td>
-    </tr>
-    <tr>
       <td>Amazon web services (AWS)</td>
       <td>
         <ul>
@@ -130,6 +122,15 @@ Have something to contribute or discuss? [Open a pull request](https://github.co
           <li>
             <div><a href="https://github.com/nelhage/rules_boost">nelhage/rules_boost</a>: Rules for Boost C++ libraries</div>
           </li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <td>C#</td>
+      <td>
+        <ul>
+          <li><a href="https://github.com/bazelbuild/rules_dotnet">bazelbuild/rules_dotnet</a></li>
+          <li><a href="https://github.com/brightspace/rules_csharp">Brightspace/rules_csharp</a>: an alternative (unofficial) design for C# rules</li>
         </ul>
       </td>
     </tr>


### PR DESCRIPTION
So I 100% won't be offended if you don't want to include these yet.

We have advertised these too widely yet because there are still some issues that we are working through for them to be considered feature complete (tracked in [milestones](https://github.com/Brightspace/rules_csharp/milestones)). That being said, we are developing them in the public and we've had some positive feedback privately in the community from people who found these rules.

We don't have a long-term idea of how to sort out having two sets of rules. The rules_dotnet rules just didn't work for us for a variety of reasons and the design we had in mind was significantly different.

I also renamed the category to C# because I thought it fit better in the table/was a more obvious place to look (e.g. "NuGet" is kind of implicit, like npm for node or cargo for Rust). If you want that change backed out, let me know.