### PR TITLE
Remove reference to github.com/zenreach/hydroponics which no longer exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -822,7 +822,6 @@ Starlark (formerly called Skylark) is Bazel's domain-specific language for writi
 - [buildbuddy-io/buildbuddy](https://github.com/buildbuddy-io/buildbuddy) - Cloud or self-hosted remote caching and execution service written in Go, with Web UI for viewing and debugging build logs
 - [BuildGrid](https://gitlab.com/BuildGrid/buildgrid) - Self-hosted remote caching and execution service written in Python
 - [Asana/bazels3cache](https://github.com/Asana/bazels3cache) - Small web server for a Bazel cache that proxies to S3, allowing Bazel to work offline and has async uploads to make Bazel faster.
-- [Zenreach/hydroponics](https://github.com/zenreach/hydroponics) - Serverless CI for Bazel making use of S3 for caching.
 
 ### Project generators
 


### PR DESCRIPTION
@Globegitter: FYI, since I think you added this. The godocs are still available, but I couldn't find the code anywhere online.