### PR TITLE
add rules_spring

### DIFF
--- a/README.md
+++ b/README.md
@@ -733,6 +733,14 @@ Have something to contribute or discuss? [Open a pull request](https://github.co
       </td>
     </tr>
     <tr>
+      <td>Spring</td>
+      <td>
+        <ul>
+          <li><a href="https://github.com/salesforce/rules_spring">salesforce/rules_spring</a></li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
       <td>Swift</td>
       <td>
         <ul>


### PR DESCRIPTION
We just finished upgrading our rules repo to [use Bazel conventions](https://docs.bazel.build/versions/master/skylark/deploying.html). What used to be *bazel-springboot-rule* is now *rules_spring*. Can we get added to the list? Thanks!