### PR TITLE
Remove samolisov/bazel-llvm-bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,6 @@ Have something to contribute or discuss? [Open a pull request](https://github.co
         <ul>
           <li><a href="https://github.com/vsco/bazel-toolchains">vsco/bazel-toolchains</a></li>
           <li><a href="https://github.com/grailbio/bazel-toolchain">grailbio/bazel-toolchain</a></li>
-          <li><a href="https://github.com/samolisov/bazel-llvm-bridge">samolisov/bazel-llvm-bridge</a>: Bazel repository_rule for using libraries from a local LLVM in your BUILD files. Supports LLVM, Clang and MLIR. Also provides the 'tablegen' rule.</li>
         </ul>
       </td>
     </tr>


### PR DESCRIPTION
Due to the LLVM community's planes to add the Bazel build files in the
project's monorepo, I see no intent for the project.

Link: https://lists.llvm.org/pipermail/llvm-dev/2021-March/149220.html