### PR TITLE
Remove dillon-giacoppo/rules_python_external

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,9 +640,6 @@ Have something to contribute or discuss? [Open a pull request](https://github.co
 	  <li>
             <div><a href="https://github.com/tubular/rules_pygen">tubular/rules_pygen</a>: Rules for generating Bazel Python libraries from requirements.txt </div>
 	  </li>
-	  <li>
-            <div><a href="https://github.com/dillon-giacoppo/rules_python_external">dillon-giacoppo/rules_python_external</a>: Rules to resolve and fetch artifacts transitively from the Python Package Index (PyPI)</div>
-	  </li>
          <li>
             <div><a href="https://github.com/TriggerMail/rules_pyz">TriggerMail/rules_pyz</a>: Python rules with PyPI package support (Unmaintained)</div>
          </li>


### PR DESCRIPTION
I upstreamed this into rules_python - that repo is now archived