### PR TITLE
Fix Building Python with Bazel link.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1038,7 +1038,7 @@ Bazel demo projects:
 - [Building Software At Google Scale](https://www.youtube.com/watch?v=6GCDfoAOKIY) - Ulf Adams, Helen Altshuler, David Stanke (Google)
 - [Bazel: Google's own build tool, now publicly available in Beta](https://www.youtube.com/watch?v=G-4jqDgILCM) - Paul Johnston
 - [Bazel at FrOSCon](https://www.youtube.com/watch?v=8p0RquTT69M) - Klaus Aehlig (Google)
-- [Building Python with Bazel](https://www.youtube.com/watch?v=i2Gu7lMVeEw) - Benjamin Peterson (Dropbox)
+- [Building Python with Bazel](https://www.youtube.com/watch?v=zaymCO1A1dM) - Benjamin Peterson (Dropbox)
 - [Bazel at the Dart Developer Summit 2016](https://www.youtube.com/watch?v=zZnGUknpFMM) - Damien Martin-Guillerez (Google)
 
 ### Podcasts


### PR DESCRIPTION
Old link pointed to private video.