### PR TITLE
rabbitmq/bazel-erlang => rabbitmq/rules_erlang

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,7 +287,7 @@ Have something to contribute or discuss? [Open a pull request](https://github.co
       <td>Erlang</td>
       <td>
         <ul>
-          <li><a href="https://github.com/rabbitmq/bazel-erlang">rabbitmq/bazel-erlang</a></li>
+          <li><a href="https://github.com/rabbitmq/rules_erlang">rabbitmq/rules_erlang</a></li>
         </ul>
       </td>
     </tr>


### PR DESCRIPTION
The repository was renamed.