### PR TITLE
Replace skydoc reference with stardoc

### DIFF
--- a/README.md
+++ b/README.md
@@ -858,7 +858,7 @@ Starlark (formerly called Skylark) is Bazel's domain-specific language for writi
 - [Language description](https://github.com/bazelbuild/starlark/)
 - [Starlark in Go](https://github.com/google/skylark)
 - [Starlark in Rust](https://github.com/google/starlark-rust)
-- [Skydoc](https://github.com/bazelbuild/skydoc) - Starlark documentation generator
+- [Stardoc](https://github.com/bazelbuild/stardoc) - Starlark documentation generator
 - [Sphinx-Bazel](https://sphinx-bazel.readthedocs.io/en/latest/) - [Sphinx](http://www.sphinx-doc.org/en/master/) extension to read Bazel files to generate documentation ([GitHub](https://github.com/useblocks/sphinx-bazel))
 - [Skylib](https://github.com/bazelbuild/bazel-skylib) - Common useful functions for writing custom build rules with Starlark
 - [aspect_bazel_lib](https://github.com/aspect-build/bazel-lib) - More common useful functions for writing custom build rules with Starlark


### PR DESCRIPTION
The former is a heavily deprecated tool and no longer supported.

Closes #118.

Signed-off-by: Abrar Rahman Protyasha <abrar.rahman98@gmail.com>