### PR TITLE
Fix VSCode link. Add Hedron Compile Commands Extractor.

### DIFF
--- a/README.md
+++ b/README.md
@@ -914,13 +914,19 @@ Tools for generating WORKSPACE and BUILD files from source code.
 	- [codesuki/bazel-mode](https://github.com/codesuki/bazel-mode):
 	- [brown/bazel-mode](https://github.com/brown/bazel-mode)
 - VSCode Support
-  - [bazelbuild/vscode-bazel](bazelbuild/vscode-bazel)
+  - [bazelbuild/vscode-bazel](https://github.com/bazelbuild/vscode-bazel)
   - [stackb/bazel-stack-vscode](https://github.com/stackb/bazel-stack-vscode).  Includes syntax highlighting / flag completion for bazelrc files.  Hover support for inline builtin-function and bazel rule documentation.  [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=StackBuild.bazel-stack-vscode).
   - [stackb/bazel-stack-vscode-cc](https://github.com/stackb/bazel-stack-vscode-cc).  Supports generation of clang compilation databases.  [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=StackBuild.bazel-stack-vscode-cc).
   - [VSCode Bazel Java extension](https://github.com/salesforce/bazel-ls-vscode) - Proof-of-concept (POC) of a Bazel Java development extension for VS Code
 - [PyCharm](https://github.com/tomhanetz/bazel-for-human-beings)
 - [sconover/rules_intellij_generate](https://github.com/sconover/rules_intellij_generate) - Plugin-less Bazel/IntelliJ integration
-- [georgewfraser/java-language-server](https://github.com/georgewfraser/java-language-server) - Java Language Server (LSP) with support for Bazel-built projects
+
+### Autocomplete for Source Code
+
+- C Language Family (C++, C, Objective-C, and Objective-C++)
+  - [hedronvision/bazel-compile-commands-extractor](https://github.com/hedronvision/bazel-compile-commands-extractor) enables autocomplete in a wide variety of extensible editors, including VSCode, Vim, Emacs, Sublime, etc.. It lets language servers, like clangd, ccls, and other tooling, draw upon Bazel’s understanding of how `cc` and `objc` code will be compiled, including, e.g., how it will configure cross compilation for other platforms.
+- Java
+  - [georgewfraser/java-language-server](https://github.com/georgewfraser/java-language-server) - Java Language Server (LSP) with support for Bazel-built projects
 
 ### BUILD file tools
 

--- a/README.md
+++ b/README.md
@@ -918,15 +918,10 @@ Tools for generating WORKSPACE and BUILD files from source code.
   - [stackb/bazel-stack-vscode](https://github.com/stackb/bazel-stack-vscode).  Includes syntax highlighting / flag completion for bazelrc files.  Hover support for inline builtin-function and bazel rule documentation.  [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=StackBuild.bazel-stack-vscode).
   - [stackb/bazel-stack-vscode-cc](https://github.com/stackb/bazel-stack-vscode-cc).  Supports generation of clang compilation databases.  [VSCode Marketplace](https://marketplace.visualstudio.com/items?itemName=StackBuild.bazel-stack-vscode-cc).
   - [VSCode Bazel Java extension](https://github.com/salesforce/bazel-ls-vscode) - Proof-of-concept (POC) of a Bazel Java development extension for VS Code
+- [hedronvision/bazel-compile-commands-extractor](https://github.com/hedronvision/bazel-compile-commands-extractor) enables autocomplete, smart navigation, quick fixes, and more in a wide variety of extensible editors, including VSCode, Vim, Emacs, Atom, and Sublime. It lets language servers, like clangd, ccls, and other types of tooling, draw upon Bazel’s understanding of how `cc` and `objc` code will be compiled, including how it configures cross-compilation for other platforms.
 - [PyCharm](https://github.com/tomhanetz/bazel-for-human-beings)
 - [sconover/rules_intellij_generate](https://github.com/sconover/rules_intellij_generate) - Plugin-less Bazel/IntelliJ integration
-
-### Autocomplete for Source Code
-
-- C Language Family (C++, C, Objective-C, and Objective-C++)
-  - [hedronvision/bazel-compile-commands-extractor](https://github.com/hedronvision/bazel-compile-commands-extractor) enables autocomplete in a wide variety of extensible editors, including VSCode, Vim, Emacs, Sublime, etc.. It lets language servers, like clangd, ccls, and other tooling, draw upon Bazel’s understanding of how `cc` and `objc` code will be compiled, including, e.g., how it will configure cross compilation for other platforms.
-- Java
-  - [georgewfraser/java-language-server](https://github.com/georgewfraser/java-language-server) - Java Language Server (LSP) with support for Bazel-built projects
+- [georgewfraser/java-language-server](https://github.com/georgewfraser/java-language-server) - Java Language Server (LSP) with support for Bazel-built projects
 
 ### BUILD file tools
 


### PR DESCRIPTION
Hi @jin! Thanks for creating this.

I'd noticed the VSCode plugin link was broken, so I fixed that. 

And then I added our compile commands extractor, parallel to that in the [bazel docs](https://docs.bazel.build/versions/main/ide.html). Hopefully that's ok; it has pretty wide usage now.

And finally, I moved the Java Language Server Plugin to that new sub-sub-subsection, since it seemed there was now a better home for it than under editors.

Thanks again!
Chris

P.S. An idea for the adjacent editors and generators section: It feels like maybe readers might be able to even more quickly find what they need if project generators were moved into the editor section, since from a user perspective, those are more like alternate implementations of editor plugins. Also because the generator heading and first line are a bit in conflict. But to keep things separate, I'll save that for a possible later change.