### PR TITLE
Adds the new official rules_android_ndk

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Have something to contribute or discuss? [Open a pull request](https://github.co
       <td>
         <ul>
           <li><a href="https://github.com/bazelbuild/rules_android">bazelbuild/rules_android</a></li>
+	  <li><a href="https://github.com/bazelbuild/rules_android_ndk">bazelbuild/rules_android_ndk</a>: Starlark rules replacing the built-in NDK rules that with more modern NDKs</li>
           <li><a href="https://github.com/quittle/bazel_android_sdk_downloader">quittle/bazel_android_sdk_downloader</a></li>: Drop-in replacement for android_sdk_repository to automatically download the Android SDK.
         </ul>
       </td>

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Have something to contribute or discuss? [Open a pull request](https://github.co
         <ul>
           <li><a href="https://github.com/bazelbuild/rules_android">bazelbuild/rules_android</a></li>
 	  <li><a href="https://github.com/bazelbuild/rules_android_ndk">bazelbuild/rules_android_ndk</a>: Starlark rules replacing the built-in NDK rules that with more modern NDKs</li>
-          <li><a href="https://github.com/quittle/bazel_android_sdk_downloader">quittle/bazel_android_sdk_downloader</a></li>: Drop-in replacement for android_sdk_repository to automatically download the Android SDK.
+          <li><a href="https://github.com/quittle/bazel_android_sdk_downloader">quittle/bazel_android_sdk_downloader</a>: Drop-in replacement for android_sdk_repository to automatically download the Android SDK.</li>
         </ul>
       </td>
     </tr>


### PR DESCRIPTION
Happened to notice it was missing while reading through PRs. 
It's the only way to use a recent NDK; the native rules last supported 5 releases ago.

I'll also fix the preexisting formatting issue just below in another commit in a second.