### PR TITLE
Add Bazel Steward for automatic dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -876,6 +876,7 @@ Have something to contribute or discuss? [Open a pull request](https://github.co
 - [renovate](https://github.com/renovatebot/renovate) - Automate WORKSPACE dependencies updates
 - [bazel-super-formatter](https://github.com/aspect-build/bazel-super-formatter) - Hermetic aggregation formatter to format code in most languages
 - [bazel-aquery-differ](https://github.com/stackb/bazel-aquery-differ) - View differences between two different aquery invocations.
+- [Bazel Steward](https://virtuslab.github.io/bazel-steward/) - Automate external dependency updates (Rules, Maven, Bazel itself)
 
 ### Toolchains
 


### PR DESCRIPTION
Bazel Steward is an open-source bot to update dependencies dedicated to Bazel projects. It runs Bazel under the hood to extract dependencies, so it should work with most setups, including custom ones.

For now, it supports only maven dependencies, Bazel version, and version of Bazel rules, but there are plans to add support for NPM, go modules, and more.