### PR TITLE
Add sign-here  under apple resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ Have something to contribute or discuss? [Open a pull request](https://github.co
           <li><a href="https://github.com/bazelbuild/rules_apple">bazelbuild/rules_apple</a></li>
           <li><a href="https://github.com/line/bazel_rules_apple">line/bazel_rules_apple</a>: LINE's custom rules for building apps and frameworks for Apple platforms</li>
           <li><a href="https://github.com/ios-bazel-users/ios-bazel-users">ios-bazel-users/ios-bazel-users</a>: Resources for using Bazel for iOS development</li>
+          <li><a href="https://github.com/Tinder/sign-here">Tinder/sign_here</a>: Provides a simple command line interface for automating the creation of signing information for Apple builds (i.e. certificates and provisioning profiles)</li>
         </ul>
       </td>
     </tr>
@@ -379,7 +380,7 @@ Have something to contribute or discuss? [Open a pull request](https://github.co
         <ul>
           <li><a href="https://github.com/tmc/rules_helm">tmc/rules_helm</a></li>
           <li><a href="https://github.com/dataform-co/dataform/tree/master/tools/helm">dataform-co/dataform/tools/helm</a>: Repository rules for downloading Helm charts, and BUILD rules for templating them</li>
-          <li><a href="https://github.com/masmovil/bazel-rules">helm bazel rules</a></li>  Bazel rules to install and manipulate Helm charts with Bazel		
+          <li><a href="https://github.com/masmovil/bazel-rules">helm bazel rules</a></li>  Bazel rules to install and manipulate Helm charts with Bazel
         </ul>
       </td>
     </tr>
@@ -1009,12 +1010,12 @@ Tools for generating WORKSPACE and BUILD files from source code.
 - [Bazel and Bazel rules tutorials from Jay Conrod](https://jayconrod.com/tags/bazel), e.g.
   - [Migrating to Bazel Part 1](https://jayconrod.com/posts/97/migrating-to-bazel--part-1)
   - [Migrating to Bazel Part 2](https://jayconrod.com/posts/98/migrating-to-bazel--part-2)
-  - [Binary rule](https://jayconrod.com/posts/106/writing-bazel-rules--simple-binary-rule)  
-  - [Library rule, depsets, providers](https://jayconrod.com/posts/107/writing-bazel-rules--library-rule--depsets--providers)  
+  - [Binary rule](https://jayconrod.com/posts/106/writing-bazel-rules--simple-binary-rule)
+  - [Library rule, depsets, providers](https://jayconrod.com/posts/107/writing-bazel-rules--library-rule--depsets--providers)
   - [Data and runfiles](https://jayconrod.com/posts/108/writing-bazel-rules--data-and-runfiles)
   - [Execution](https://jayconrod.com/posts/109/writing-bazel-rules--moving-logic-to-execution)
-  - [Repository rules](https://jayconrod.com/posts/110/writing-bazel-rules--repository-rules)   
-  - [Platforms and toolchains](https://jayconrod.com/posts/111/writing-bazel-rules-platforms-and-toolchains)  
+  - [Repository rules](https://jayconrod.com/posts/110/writing-bazel-rules--repository-rules)
+  - [Platforms and toolchains](https://jayconrod.com/posts/111/writing-bazel-rules-platforms-and-toolchains)
   - [WORKSPACE files](https://jayconrod.com/posts/115/organizing-bazel-workspace-files)
 
 ### Projects


### PR DESCRIPTION
sign-here can easily fill a gap that xcode provides in terms of generating signing identities.
This tool is also built with bazel