### PR TITLE
Add f0rmiga/gcc-toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -904,6 +904,7 @@ Toolchains enable authors to decouple their rule logic from platform-based selec
 - [vsco/bazel-toolchains](https://github.com/vsco/bazel-toolchains) - A collection of Bazel C++ build infrastructure based on Chromium's LLVM toolchain
 - [grailbio/bazel-toolchain](https://github.com/grailbio/bazel-toolchain) - LLVM toolchain for bazel
 - [bazelembedded/bazel-embedded](https://github.com/bazelembedded/bazel-embedded) - Set of bazel toolchains and tools, for compiling and uploading to embedded targets
+- [f0rmiga/gcc-toolchain](https://github.com/f0rmiga/gcc-toolchain) - A fully-hermetic Bazel GCC toolchain for Linux
 
 ### Starlark
 


### PR DESCRIPTION
A fully-hermetic Bazel GCC toolchain for Linux.